### PR TITLE
Fix wrong indent of encryption: key in config.yaml

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -126,7 +126,7 @@ bridge:
     #
     # Additionally, https://github.com/matrix-org/synapse/pull/5758 is required if using a normal
     # application service.
-        encryption:
+    encryption:
         # Allow encryption, work in group chat rooms with e2ee enabled
         allow: __ENCRYPTION__
         # Default to encryption, force-enable encryption in all portals the bridge creates


### PR DESCRIPTION
A typo in indentation caused parsing error on reading config file.

## Problem
- *Description of why you made this PR*

## Solution
- *And how do you fix that problem*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/mautrix_googlechat_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/mautrix_googlechat_ynh%20PR-NUM-%20(USERNAME)/)  
